### PR TITLE
UHM-4087 Default end date for Lab Workflow filter is yesterday

### DIFF
--- a/src/components/widgets/CustomDatePicker.jsx
+++ b/src/components/widgets/CustomDatePicker.jsx
@@ -119,7 +119,8 @@ class CustomDatePicker extends PureComponent {
     const { input, usePortalMode } = otherProps;
     const { selectedDate } = this.state;
     let error;
-    let selected = new Date(selectedDate);
+    const parts = selectedDate.split('-');
+    let selected = new Date(parts[0], parts[1] - 1, parts[2]); 
     let validations = "";
 
     const hasInput = typeof input !== 'undefined';

--- a/src/components/widgets/CustomDatePicker.jsx
+++ b/src/components/widgets/CustomDatePicker.jsx
@@ -119,8 +119,7 @@ class CustomDatePicker extends PureComponent {
     const { input, usePortalMode } = otherProps;
     const { selectedDate } = this.state;
     let error;
-    const parts = selectedDate.split('-');
-    let selected = new Date(parts[0], parts[1] - 1, parts[2]); 
+    let selected = parse(selectedDate); 
     let validations = "";
 
     const hasInput = typeof input !== 'undefined';


### PR DESCRIPTION
Parsing of date strings with the Date constructor is strongly discouraged due to browser differences and inconsistencies. See note of this link for more details:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date


For example:

```
console.log(new Date("2019-09-30")) 
// return  Sun Sep 29 2019 20:00:00 GMT-0400 (Eastern Daylight Time)
```

