### PR TITLE
Fixed forced redirection while using localization header drop-down

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -71,8 +71,7 @@ export class Header extends React.Component {
 
             </li>
             <li className="change-location">
-              <a 
-                href="#"
+              <a
                 onClick={() => { this.toggleState("locationDropdown"); }}
               >
                 <i className="icon-map-marker small" />

--- a/src/components/header/__tests__/__snapshots__/Header.test.jsx.snap
+++ b/src/components/header/__tests__/__snapshots__/Header.test.jsx.snap
@@ -49,7 +49,6 @@ exports[`header should render correctly 1`] = `
         className="change-location"
       >
         <a
-          href="#"
           onClick={[Function]}
         >
           <i


### PR DESCRIPTION
I found that opening a location drop-down from the Header component was redirecting a user to the module's home page. An example is shown in the gif below.
![route#](https://user-images.githubusercontent.com/7571152/66906989-e42bef80-f008-11e9-94ae-13211d8a86f6.gif)
The reason was hardcoded href="#". Here is a simple solution. Please, let me know if that's helpful.
