### PR TITLE
RA-2020: Fixed auto update of translations from transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,9 @@
 [main]
 host = https://www.transifex.com/
 
-[OpenMRS.react-components]
+[o:openmrs:p:OpenMRS:r:react-components]
 file_filter = src/localization/translations/<lang>.json
 source_file = src/localization/translations/en.json
 source_lang = en
-type = KEYVALUEJSON
+type        = KEYVALUEJSON
 


### PR DESCRIPTION
**Description**
Updated my transifex client.
Running tx migrate created a back up for previous config.
Runningtx pull --all -f I was able to pull down all message property translation files and have them update the source on my machine. The -f flag ensured that my machine was updated from the server, even if the files were newer. I then committed these changes back to the repo.

**Related Issue**
see https://issues.openmrs.org/browse/RA-2020